### PR TITLE
Add Skillpoint rewards after battle and -skill command to use them

### DIFF
--- a/src/commands/adventure-commands.ts
+++ b/src/commands/adventure-commands.ts
@@ -34,7 +34,7 @@ interface PlayerResult {
     baseDamage: number,
     critDamage: number,
     totalDamage: number,
-
+    goldLoss: number,
     // Can add 'fumbled', 'crit' etc to this later
 }
 
@@ -43,6 +43,7 @@ interface PlayerAttack {
     roll: number,
     baseDamage: number,
     critDamage: number,
+    goldLoss: number,
 }
 
 class AdventureCommands extends BaseCommands {
@@ -205,7 +206,7 @@ class AdventureCommands extends BaseCommands {
 
             for (let i = 0; i < users.length; i++) {
                 const player: IPlayer | null = await Player.findOne({ id: users[i].id }).exec();
-                const playerAttack: PlayerAttack = player?.attackEnemy(adventure.enemy, action);
+                const playerAttack: PlayerAttack = player?.attackEnemy(adventure.enemy, action, adventure.area);
 
                 const playerResult = <PlayerResult>{
                     player,
@@ -214,6 +215,7 @@ class AdventureCommands extends BaseCommands {
                     baseDamage: playerAttack.baseDamage,
                     critDamage: playerAttack.critDamage,
                     totalDamage: playerAttack.baseDamage + playerAttack.roll,
+                    goldLoss: playerAttack.goldLoss,
                 };
 
                 allPlayerResults.push(playerResult);
@@ -231,6 +233,8 @@ class AdventureCommands extends BaseCommands {
 
         if (totalDamage >= adventure.enemy.baseHp) {
             won = true;
+
+            
 
             const allRewardResults: Array<RewardResult> = [];
             const allSkillpointRewards: Array<EarnedSkillpoints> = [];
@@ -272,13 +276,25 @@ class AdventureCommands extends BaseCommands {
                     this.message.channel.send(makeStandardMessage(`The enemy dropped one ${adventure.area.questItem}. You now have (${questItems}/${adventure.area.totalQuestItemsNeeded}) ${adventure.area.name} quest items.`));
                 }
             }
+
+            let levelUpCount = 0;
+
+            for (let i = 0; i < allSkillpointRewards.length; i++) {
+                if(allSkillpointRewards[i].levelUp == true){
+                    levelUpCount++;
+                }
+            }
+
+            
             const adventureRewardsMessageWin = makeAdventureRewards(allPlayerResults, allRewardResults);
             this.message.channel.send(adventureRewardsMessageWin);
 
             console.log(allSkillpointRewards);
 
+            if(levelUpCount > 0){
             const earnedSkillpointsMessage = makeEarnedSkillpoints(allSkillpointRewards);
             this.message.channel.send(earnedSkillpointsMessage);
+            }
 
             await this.guild.gainExperience(totalXp * 0.2);
             await this.guild.giveCurrency(totalGold * 0.2);

--- a/src/commands/generic-commands.ts
+++ b/src/commands/generic-commands.ts
@@ -12,6 +12,8 @@ import { makeStatsMessage } from "../messages/stats";
 import { Player, IPlayer } from '../models/Player';
 import BaseCommands from "./base-commands";
 import { makeShowHeroclassesMessage } from "../messages/show-heroclasses";
+import { makeInsufficientSkillpointsMessage } from "../messages/insufficient-skillpoints";
+import { makeUsedSkillpointsMessage } from "../messages/used-skillpoints";
 
 class GenericCommands extends BaseCommands {
     // stats([first, last]: [string?, string?]) {
@@ -72,6 +74,36 @@ class GenericCommands extends BaseCommands {
         }
 
         this.message.channel.send(makeStatsMessage(player));
+       
+    }
+
+    async skillpoints(skill: string, amount?: number) {
+        let targetPlayerId = this.message.author.id;
+
+        const player: IPlayer | null = await Player.findOne({ id: targetPlayerId }).exec();
+
+        if (!player) {
+            this.message.channel.send('Player not found. Please try again');
+            return;
+        }
+
+        if (!skill){
+            this.message.channel.send(makeErrorMessage(`You must include the desired skill using -skill [skill name]!`));
+            return;
+        }
+
+        const useSkill = await player.useSkillpoints(skill, amount, player);
+
+        if(!useSkill.worked){
+        const skillpointsNotUsedMessage = makeInsufficientSkillpointsMessage(player.username);
+        this.message.channel.send(skillpointsNotUsedMessage);
+        }
+
+        if(useSkill.worked){
+        const skillpointsUsedMessage = makeUsedSkillpointsMessage(useSkill);
+        this.message.channel.send(skillpointsUsedMessage);
+        }
+
     }
 
     // Lets players select their Heroclass

--- a/src/config/available-commands.ts
+++ b/src/config/available-commands.ts
@@ -9,6 +9,7 @@ export default {
     stats: { class: GenericCommands, method: 'stats' },
     heroclass: { class: GenericCommands, method: 'selectHeroclass' },
     rebirth: { class: GenericCommands, method: 'rebirth' },
+    skill: {class: GenericCommands, method: 'skillpoints'},
 
     // Adventuring Commands
     adventure: { class: AdventureCommands, method: 'adventure' },

--- a/src/messages/adventure-results.ts
+++ b/src/messages/adventure-results.ts
@@ -7,7 +7,7 @@ const makeAdventureResults = (won: boolean, enemy: IEnemy | IBoss, absoluteDamge
 
     let desc = [
         `The group killed the ${enemy.name} **(${absoluteDamge}/${enemy.baseHp})**.`,
-        `TODO: Make this clever`,
+        `Attack Party:`,
     ];
 
     if (!won) {
@@ -15,7 +15,10 @@ const makeAdventureResults = (won: boolean, enemy: IEnemy | IBoss, absoluteDamge
 
         desc = [
             `The group got killed by the ${enemy.name} **(${absoluteDamge}/${enemy.baseHp})**.`,
-            `TODO: Make this clever`,
+            ``,
+            `You tried your best, but couldn't succeed; each of you used ${allPlayerResults[0].goldLoss} gold to repair your gear.`,
+            ``,
+            `Attack Party:`,
         ];
     }
 

--- a/src/messages/earned-skillpoints-and-levelup.ts
+++ b/src/messages/earned-skillpoints-and-levelup.ts
@@ -1,0 +1,42 @@
+import { EmbedFieldData } from 'discord.js';
+import { MessageEmbed } from 'discord.js';
+import { IBoss, IEnemy } from "../interfaces/enemy";
+import { PlayerResult } from "../commands/adventure-commands";
+import { EarnedSkillpoints } from "../models/Player";
+
+const makeEarnedSkillpoints = (allSkillpointRewards: EarnedSkillpoints[]) => {
+
+    let desc = [
+        `Use them wisely.`,
+        
+    ];
+
+    
+
+    // \n💥 Bonus Damage: 301
+    let embed = new MessageEmbed()
+        .setTitle(`Congratulations on achieving a new level, here are your skillpoints!`)
+        .setColor('DARK_GREEN') // WIN/LOSE colours
+        .setDescription(desc.join('\n'))
+    for (let i = 0; i < allSkillpointRewards.length; i++) {
+        
+        let end = 's!';
+
+        if (allSkillpointRewards[i].totalSkillpoints === 1){
+            end = '!';         
+        }
+        console.log(allSkillpointRewards[i].totalSkillpoints);
+        embed.addFields(
+            <EmbedFieldData>{
+                name: `${allSkillpointRewards[i].player.username}`,
+                value: `🌟 Your new level is **${allSkillpointRewards[i].level}**, and you've earned **${allSkillpointRewards[i].totalSkillpoints}** Skillpoint${end}`,
+                inline: false,
+            },
+            // Bonus Damage Not Added Yet
+        )
+
+    }
+    return embed;
+}
+
+export { makeEarnedSkillpoints };

--- a/src/messages/earned-skillpoints-and-levelup.ts
+++ b/src/messages/earned-skillpoints-and-levelup.ts
@@ -15,21 +15,28 @@ const makeEarnedSkillpoints = (allSkillpointRewards: EarnedSkillpoints[]) => {
 
     // \n💥 Bonus Damage: 301
     let embed = new MessageEmbed()
-        .setTitle(`Congratulations on achieving a new level, here are your skillpoints!`)
         .setColor('DARK_GREEN') // WIN/LOSE colours
-        .setDescription(desc.join('\n'))
     for (let i = 0; i < allSkillpointRewards.length; i++) {
+        
         
         let end = 's!';
 
         if (allSkillpointRewards[i].totalSkillpoints === 1){
             end = '!';         
         }
+        
+        let fieldValue = `, and you've earned **${allSkillpointRewards[i].totalSkillpoints}** Skillpoint${end}`
+
+
+        if(allSkillpointRewards[i].totalSkillpoints === 0){
+            fieldValue = `!`
+        }
+
         console.log(allSkillpointRewards[i].totalSkillpoints);
         embed.addFields(
             <EmbedFieldData>{
                 name: `${allSkillpointRewards[i].player.username}`,
-                value: `🌟 Your new level is **${allSkillpointRewards[i].level}**, and you've earned **${allSkillpointRewards[i].totalSkillpoints}** Skillpoint${end}`,
+                value: `⏫🌟 Your new level is **${allSkillpointRewards[i].level}**${fieldValue}`,
                 inline: false,
             },
             // Bonus Damage Not Added Yet

--- a/src/messages/insufficient-skillpoints.ts
+++ b/src/messages/insufficient-skillpoints.ts
@@ -1,0 +1,9 @@
+import { MessageEmbed } from 'discord.js';
+
+const makeInsufficientSkillpointsMessage = (id: string) => {
+    return new MessageEmbed()
+        .setDescription(`Sorry ${id}! You don't have enough skillpoints!`)
+        .setColor('RED');
+}
+
+export { makeInsufficientSkillpointsMessage };

--- a/src/messages/used-skillpoints.ts
+++ b/src/messages/used-skillpoints.ts
@@ -1,0 +1,18 @@
+import { MessageEmbed } from 'discord.js';
+import { SkillpointResults } from '../models/Player'
+
+const makeUsedSkillpointsMessage = (skillpointResults: SkillpointResults) => {
+
+    let end = 's';
+    const caseCorrected = skillpointResults.skill.charAt(0).toUpperCase() + skillpointResults.skill.slice(1).trim();
+    
+    if (skillpointResults.finalPoints == 1){
+        end = '';
+    }
+
+    return new MessageEmbed()
+        .setDescription(`Congratulations ${skillpointResults.player.username}! You now have ${skillpointResults.finalPoints} skillpoint${end} in ${caseCorrected}`)
+        .setColor('DARK_GREEN');
+}
+
+export { makeUsedSkillpointsMessage };

--- a/src/models/Player.ts
+++ b/src/models/Player.ts
@@ -554,6 +554,14 @@ PlayerSchema.methods.rebirth = async function () {
         throw new Error('Cannot rebirth');
     }
 
+    const options: Array<String> = ['attack', 'charisma', 'intelligence','unspent'];
+    
+
+    for (let i = 0; i <= options.length; i++) {
+        const currentPointsInSkill = this.get(`skillpoints.${options[i]}`);
+        const newPointsInSkill = this.set(`skillpoints.${options[i]}`, 0 );
+    }
+
     this.experience = 1;
     this.level = 1;
 


### PR DESCRIPTION
Add skillpoint rewards after battle and -skill command to use them, also with properly formatted rewards screen. I also added all the shorthand (att, int, cha...etc) and if you leave out the amount it automatically knows it's one point. Only thing left to do tomorrow is to make base stats rise appropriately upon rebirth, and make the levelup/skillpoints message not appear at all if nobody leveled up. Enjoy!